### PR TITLE
Path to jquery-1.6.1.min.js fixed

### DIFF
--- a/tapestry-commons/tapestry-jquery/src/main/java/uk/co/ioko/tapestry/jquery/services/JQueryStack.java
+++ b/tapestry-commons/tapestry-jquery/src/main/java/uk/co/ioko/tapestry/jquery/services/JQueryStack.java
@@ -36,7 +36,7 @@ public class JQueryStack implements JavaScriptStack {
 
         String jquery;
         if (productionMode) {
-            jquery = "uk/co/ioko/tapestry/jquery/pages/jquery-1.6.1-min.js";
+            jquery = "uk/co/ioko/tapestry/jquery/pages/jquery-1.6.1.min.js";
         } else {
             jquery = "uk/co/ioko/tapestry/jquery/pages/jquery-1.6.1.js";
         }


### PR DESCRIPTION
Please find attached a commit that fixes an invalid path to the jquery-1.6.1.min.js resource.
The bug results in an incomplete jquery library stack if production mode is enabled.
